### PR TITLE
Correct CR+LF bug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Autodetect text files
+* text=lf


### PR DESCRIPTION
Due to the bug with CR+LF, it's corrected.
I force github to send LF file via gitattributes